### PR TITLE
Gen fixes and other tweaks

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -39,6 +39,9 @@ class CupheadWorld(World):
     item_name_to_id = items.name_to_id
     location_name_to_id = locations.name_to_id
 
+    # TODO: Move item_name_groups definition to be static
+    #item_name_groups = {}
+
     item_names = set(items.items_all.keys())
     location_names = set(locations.locations_all.keys())
 
@@ -78,12 +81,13 @@ class CupheadWorld(World):
             self.level_shuffle_map: dict[int,int] = levels.setup_level_shuffle_map(self.random, self.wsettings)
 
         # Shop Map (shop_index(weapons, charms)) # TODO: Maybe shuffle the amounts later
-        self.shop_map: list[tuple[int]] = self.get_shop_map()
+        self.shop_map: list[tuple[int, int]] = self.get_shop_map()
         self.shop_locations: dict[str,list[str]] = self.get_shop_locations()
 
         self.contract_requirements: tuple[int,int,int] = self.wsettings.contract_requirements
         self.dlc_ingredient_requirements: int = self.wsettings.dlc_ingredient_requirements
 
+        # TODO: Move item_name_groups definition to be static
         # Group Items
         self.item_name_groups = self.get_item_groups()
 
@@ -118,7 +122,7 @@ class CupheadWorld(World):
             slot_data.update(self.options.as_dict(option))
         return slot_data
 
-    def get_shop_map(self) -> list[tuple[int]]:
+    def get_shop_map(self) -> list[tuple[int, int]]:
         return [(2,2), (2,2), (1,2), (3,2)] if not self.use_dlc else [(2,2), (2,2), (2,2), (2,2)]
 
     def get_shop_locations(self) -> dict[str,list[str]]:
@@ -208,7 +212,7 @@ class CupheadWorld(World):
             return super().collect(state, item)
 
     def get_filler_item_name(self) -> str:
-        itembase.get_filler_item_name(self)
+        return itembase.get_filler_item_name(self)
 
     def extend_hint_information(self, hint_data: Dict[int, Dict[int, str]]):
         hint_dict: Dict[int, str] = {}

--- a/__init__.py
+++ b/__init__.py
@@ -49,13 +49,13 @@ class CupheadWorld(World):
         if not self.options.use_dlc:
             # Sanitize mode
             if int(self.options.mode)>1:
-                self.options.mode = self.random.randint(0,1)
+                self.options.mode.value = self.random.randint(0,1)
             # Sanitize start_weapon
             if int(self.options.start_weapon.value)>5:
                 self.options.start_weapon.value = self.random.randint(0,5)
         # Sanitize grade checks
         if not self.options.expert_mode and int(self.options.boss_grade_checks)>3:
-            self.options.boss_grade_checks = 3
+            self.options.boss_grade_checks.value = 3
 
         # Settings (See Settings.py)
         self.wsettings = WorldSettings(self.options)

--- a/auxiliary.py
+++ b/auxiliary.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 def count_in_list(e, ls: list):
     count = 0
     for el in ls:
@@ -18,7 +20,7 @@ def format_list(ls: list) -> str:
     res += "]"
     return res
 
-def scrub_list(a: list, b: set) -> list:
+def scrub_list(a: list, b: Iterable) -> list:
     newlist: list = []
     for item in a:
         if item in b:

--- a/levels.py
+++ b/levels.py
@@ -34,14 +34,15 @@ def level_rule_dash(settings: WorldSettings) -> RegionRule:
 def level_rule_parry(settings: WorldSettings) -> RegionRule:
     if not settings.randomize_abilities:
         return level_rule_none(settings)
+    return region_rule_has(ItemNames.item_ability_parry)
 def level_rule_dash_or_parry(settings: WorldSettings) -> RegionRule:
     if not settings.randomize_abilities:
         return level_rule_none(settings)
-    return level_rule_or(level_rule_dash, level_rule_parry)
+    return level_rule_or(level_rule_dash, level_rule_parry)(settings)
 def level_rule_dash_and_parry(settings: WorldSettings) -> RegionRule:
     if not settings.randomize_abilities:
         return level_rule_none(settings)
-    return level_rule_and(level_rule_dash, level_rule_parry)
+    return level_rule_and(level_rule_dash, level_rule_parry)(settings)
 def level_rule_plane_parry(settings: WorldSettings) -> RegionRule:
     if not settings.randomize_abilities:
         return level_rule_none(settings)

--- a/levels.py
+++ b/levels.py
@@ -431,7 +431,7 @@ def setup_level_shuffle_map(rand: Random, settings: WorldSettings) -> dict[int,i
 
 def shuffle_levels(rand: Random, level_list: list[str], level_exclude_list: list[str] = None) -> dict[int, int]:
     res: dict[int, int] = {}
-    excludes = level_exclude_list if level_exclude_list else []
+    excludes: list[int] = level_exclude_list if level_exclude_list else []
     _levels = [level_id_map[x] for x in level_list if (x not in excludes)]
 
     levels_shuffled = list(_levels)

--- a/regiondefs.py
+++ b/regiondefs.py
@@ -59,14 +59,14 @@ class WorldRegionData(RegionData):
     def __init__(self, name: str, add_locations: list[str] = None, connect_to: list[Target] = None, depends: Optional[Dep] = None, flags: DefFlags = 1):
         super().__init__(name, add_locations, connect_to, depends, DefType.WORLD, flags)
 
-region_begin = RegionData("Menu", None, [Target(LocationNames.level_house)], flags=1)
+region_begin = RegionData("Menu", None, [Target(LocationNames.level_house)], flags=DefFlags.TGT_IGNORE_FREEMOVE)
 region_house = RegionData(LocationNames.level_house, None, [
-    Target(LocationNames.level_tutorial), Target(LocationNames.world_inkwell_1)], flags=1)
+    Target(LocationNames.level_tutorial), Target(LocationNames.world_inkwell_1)], flags=DefFlags.TGT_IGNORE_FREEMOVE)
 
 region_house_level_tutorial = RegionData(LocationNames.level_tutorial, [
     LocationNames.loc_level_tutorial,
     LocationNames.loc_level_tutorial_coin,
-], None, flags=1)
+], None, flags=DefFlags.TGT_IGNORE_FREEMOVE)
 
 region_worlds = [
     WorldRegionData(LocationNames.world_inkwell_1, [
@@ -255,7 +255,7 @@ region_isle3 = [
     RegionData(LocationNames.loc_quest_pacifist, [LocationNames.loc_quest_pacifist], None, dep.dep_pacifist_quest),
 ]
 region_isleh = [
-    LevelRegionData(LocationNames.level_boss_kingdice, None, [LevelTarget(LocationNames.level_boss_devil)], flags=1),
+    LevelRegionData(LocationNames.level_boss_kingdice, None, [LevelTarget(LocationNames.level_boss_devil)], flags=DefFlags.TGT_IGNORE_FREEMOVE),
     #LevelRegionData(LocationNames.level_boss_devil, None, None),
     RegionData(LocationNames.level_boss_devil, [LocationNames.loc_event_goal_devil]), #FIXME: Temp
 ]
@@ -277,7 +277,7 @@ region_dlc_isle4 = [
         LevelTarget(LocationNames.level_dlc_boss_airplane),
         #LevelTarget(LocationNames.level_dlc_graveyard),
     ]),
-    LevelRegionData(LocationNames.level_dlc_boss_airplane, [
+    LevelRegionData(LocationNames.level_dlc_boss_airplane, None, [
         LevelTarget(LocationNames.level_dlc_boss_snowcult),
         LevelTarget(LocationNames.level_dlc_boss_plane_cowboy),
         Target(LocationNames.loc_dlc_quest_cactusgirl, None, dep.dep_dlc_cactusgirl_quest),
@@ -287,17 +287,17 @@ region_dlc_isle4 = [
     #LevelRegionData(LocationNames.level_dlc_graveyard, None),
     RegionData(LocationNames.level_dlc_chesscastle, None, [
         LevelTarget(LocationNames.level_dlc_chesscastle_pawn)
-    ], flags=1),
+    ], flags=DefFlags.TGT_IGNORE_FREEMOVE),
     RegionData(LocationNames.loc_dlc_quest_cactusgirl, [LocationNames.loc_dlc_quest_cactusgirl], None, dep.dep_dlc_cactusgirl_quest),
 ]
 region_dlc_chesscastle = [
     # Setup Regions later
-    LevelRegionData(LocationNames.level_dlc_chesscastle_pawn, None, [LevelTarget(LocationNames.level_dlc_chesscastle_knight)], flags=1),
-    LevelRegionData(LocationNames.level_dlc_chesscastle_knight, None, [LevelTarget(LocationNames.level_dlc_chesscastle_bishop)], flags=1),
-    LevelRegionData(LocationNames.level_dlc_chesscastle_bishop, None, [LevelTarget(LocationNames.level_dlc_chesscastle_rook)], flags=1),
-    LevelRegionData(LocationNames.level_dlc_chesscastle_rook, None, [LevelTarget(LocationNames.level_dlc_chesscastle_queen)], flags=1),
-    LevelRegionData(LocationNames.level_dlc_chesscastle_queen, None, [LevelTarget(LocationNames.level_dlc_chesscastle_run)], flags=1),
-    LevelRegionData(LocationNames.level_dlc_chesscastle_run, None, flags=1)
+    LevelRegionData(LocationNames.level_dlc_chesscastle_pawn, None, [LevelTarget(LocationNames.level_dlc_chesscastle_knight)], flags=DefFlags.TGT_IGNORE_FREEMOVE),
+    LevelRegionData(LocationNames.level_dlc_chesscastle_knight, None, [LevelTarget(LocationNames.level_dlc_chesscastle_bishop)], flags=DefFlags.TGT_IGNORE_FREEMOVE),
+    LevelRegionData(LocationNames.level_dlc_chesscastle_bishop, None, [LevelTarget(LocationNames.level_dlc_chesscastle_rook)], flags=DefFlags.TGT_IGNORE_FREEMOVE),
+    LevelRegionData(LocationNames.level_dlc_chesscastle_rook, None, [LevelTarget(LocationNames.level_dlc_chesscastle_queen)], flags=DefFlags.TGT_IGNORE_FREEMOVE),
+    LevelRegionData(LocationNames.level_dlc_chesscastle_queen, None, [LevelTarget(LocationNames.level_dlc_chesscastle_run)], flags=DefFlags.TGT_IGNORE_FREEMOVE),
+    LevelRegionData(LocationNames.level_dlc_chesscastle_run, None, flags=DefFlags.TGT_IGNORE_FREEMOVE)
 ]
 region_dlc_special = [
     # Add Logic Regions and connections to curse_complete

--- a/regions.py
+++ b/regions.py
@@ -74,7 +74,7 @@ def connect_region_targets(world: CupheadWorld, regc: RegionData, locset: set[st
                     for loc in tgt.locations:
                         if loc not in locset:
                             locset.add(loc.name)
-                src.connect(tgt, name, (lambda state, player=player, rule=_rule: rule(state, player)) if _rule else None)
+                src.connect(tgt, name, (lambda state, plyr=player, rule=_rule: rule(state, plyr)) if _rule else None)
             #else:
             #    print("Skipping Target "+target.name) # if debug
         else:

--- a/rules.py
+++ b/rules.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import typing
-from BaseClasses import Location, Region
+from BaseClasses import Location, Region, Entrance
 from worlds.generic.Rules import set_rule, forbid_item, forbid_items_for_player
 from .items import item_filler
 from .names import ItemNames, LocationNames
@@ -9,7 +9,7 @@ from . import locations
 if typing.TYPE_CHECKING:
     from . import CupheadWorld
 
-def get_entrance(world: CupheadWorld, exit: str, entrance: str) -> Location:
+def get_entrance(world: CupheadWorld, exit: str, entrance: str) -> Entrance:
     return world.multiworld.get_entrance(exit+" -> "+entrance, world.player)
 def get_location(world: CupheadWorld, location: str) -> Location:
     return world.multiworld.get_location(location, world.player)


### PR DESCRIPTION
This fixes a few crashes during generation with various settings including plando, as well as fixes some type hinting. You'll still need to set item_name_groups statically but that's a more complex fix and I'm not 100% sure how you want to organize that.

This was tested by generating a few 1000 player multiworlds with all functional options set to random. The client has not been tested, only the apworld.